### PR TITLE
Use podman instead docker

### DIFF
--- a/hack/yamllint.sh
+++ b/hack/yamllint.sh
@@ -2,7 +2,7 @@
 if [ "$IS_CONTAINER" != "" ]; then
   yamllint ./plugins/
 else
-  docker run --rm \
+  podman run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/workdir:z" \
     --entrypoint sh \


### PR DESCRIPTION
This PR switches from docker to podman, since podman is more used in release repo and images mostly have builtin podman.